### PR TITLE
Wait for 60 seconds (instead of 20) for image resize.

### DIFF
--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -109,7 +109,7 @@
         auth: "{{ ovirt_auth }}"
       register: resized_disk
       until: resized_disk.disk.provisioned_size != ovirt_disk.disk.provisioned_size
-      retries: 10
+      retries: 30
       delay: 2
     when:
       - (template_disk_size | regex_replace('GiB') | int) > (qcow2_size | regex_replace('GiB') | int)


### PR DESCRIPTION
On some storage, it may take more than 20 seconds, no need to fail
just because the storage is somewhat slow.