### PR TITLE
Don't hardcode temp file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Role Variables
 | Name               | Default value         |                            |
 |--------------------|-----------------------|----------------------------|
 | qcow_url           | UNDEF                 | The URL of the QCOW2 image. |
-| image_path         | /tmp/ovirt_image_data | Path where the QCOW2 image will be downloaded to. |
+| image_path         | /tmp/                 | Path where the QCOW2 image will be downloaded to. If directory the base name of the URL on the remote server will be used. |
+| image_checksum     | UNDEF                 | If a checksum is defined, the digest of the destination file will be calculated after it is downloaded to ensure its integrity and verify that the transfer completed successfully. Format: <algorithm>:<checksum>, e.g. checksum="sha256:D98291AC[...]B6DC7B97". |
 | image_cache_download | true                | When set to false will delete image_path at the start and end of execution |
 | template_cluster   | Default               | Name of the cluster where template must be created. |
 | template_name      | mytemplate            | Name of the template. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-image_path: /tmp/ovirt_image_data
+image_path: /tmp/
 image_cache_download: true
 template_cluster: Default
 template_name: mytemplate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,5 @@
     msg: "You must either specify qcow_url or glance_image"
   when: "glance_image is defined and qcow_url is defined"
 
-- name: Glance image
-  include: glance_image.yml
-  when: "glance_image is defined"
-
-- name: QCOW2 image
-  include: qcow2_image.yml
-  when: "qcow_url is defined"
+- name: Image upload
+  include_tasks: "{{ (glance_image is defined) | ternary('glance', 'qcow2') }}_image.yml"

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -4,12 +4,13 @@
     url: "{{ qcow_url }}"
     dest: "{{ image_path }}"
     force: "{{ not image_cache_download }}"
-  register: downloaded
+    checksum: "{{ image_checksum | default(omit) }}"
+  register: downloaded_file
   tags:
     - ovirt-template-image
 
 - name: Check file type
-  command: "/usr/bin/file {{ image_path | quote }}"
+  command: "/usr/bin/file {{ downloaded_file.dest | quote }}"
   changed_when: false
   register: filetype
   tags:
@@ -24,7 +25,7 @@
 
 - name: Calculate image size in GiB
   set_fact:
-    qcow2_size: "{{ filetype.stdout_lines[0].split()[5] | int // 2**30 }}GiB"
+    qcow2_size: "{{ (filetype.stdout_lines[0].split()[5] | int / 2**30) | round(0, 'ceil') | int }}GiB"
 
 - block:
   - name: Login to oVirt
@@ -68,7 +69,7 @@
       name: "{{ template_disk_name | default(template_name) }}"
       size: "{{ qcow2_size }}"
       format: "{{ template_disk_format | default(omit) }}"
-      image_path: "{{ image_path }}"
+      image_path: "{{ downloaded_file.dest }}"
       storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
       force: "{{ ovirt_templates | length == 0 }}"
     register: ovirt_disk
@@ -130,7 +131,7 @@
   always:
     - name: Remove downloaded image
       file:
-        path: "{{ image_path }}"
+        path: "{{ downloaded_file.dest }}"
         state: absent
       when:  not image_cache_download
 


### PR DESCRIPTION
By default download the file to /tmp directory to file name same as url
base name. But let user change the name of the file.

 - if there is small qcow file, we need to round the size to up, so
   the lowest size is 1GiB.
 - get rid of 'skipped' by using include_tasks dynamicall by variable
   instead of using "when".
 - add checksum to get_url module using variable image_checksum.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1575411

Change-Id: I263f90edc61f7177b46afe266137f21a6fe7ab37
Signed-off-by: Ondra Machacek <omachace@redhat.com>