### PR TITLE
Wait until the qcow image is unlocked by the oVirt engine

### DIFF
--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -94,6 +94,16 @@
       tags:
         - ovirt-template-image
 
+    - name: Wait until the qcow image is unlocked by the oVirt engine
+      ovirt_disk_facts:
+        auth: "{{ ovirt_auth }}"
+        pattern: "id={{ ovirt_disk.id }}"
+      until: (ovirt_disks is defined) and (ovirt_disks[0].status != "locked")
+      retries: 10
+      delay: 3
+      tags:
+        - ovirt-template-image
+
     - block:
       - name: Generate SSH keys
         command: "ssh-keygen -t rsa -f {{ tmp_private_key_file }} -N ''"


### PR DESCRIPTION
On a very busy oVirt engine (or when there is a considerable latency between the Ansible controller and the API), it's possible that the API will release the QCOW2 upload process, but the disk will remain locked for a while. The API will not allow to create a new VM until the disk is unlocked.

This patch introduces a small delay (30 seconds) which the playbook will keep querying the API until the image is unlocked.