### PR TITLE
add template_seal variable otherwise it fails on Windows templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Role Variables
 | template_disk_name | UNDEF                 | The name of template disk.  |
 | template_disk_format | UNDEF               | Format of the template disk.  |
 | template_disk_interface | virtio           | Interface of the template disk. |
+| template_seal      | true                  | 'Sealing' erases all machine-specific configurations from a filesystem. Not supported on Windows. Set this to 'false' for Windows.  |
 | template_timeout   | 600                   | Amount of time to wait for the template to be created. |
 | template_type      | UNDEF                 | The type of the template: desktop, server or high_performance (for qcow2 based templates only) |
 | template_nics      | {name: nic1, profile_name: ovirtmgmt, interface: virtio} | List of dictionaries that specify the NICs of template. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,5 +13,6 @@ template_nics:
   - name: nic1
     profile_name: ovirtmgmt
     interface: virtio
+template_seal: true
 
 disk_storage_domain: null

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -196,7 +196,7 @@
         vm: "{{ vm_name }}"
         cluster: "{{ template_cluster }}"
         timeout: "{{ template_timeout }}"
-        seal: true
+        seal: "{{ template_seal }}"
       when: ovirt_templates | length == 0
       tags:
         - ovirt-template-image


### PR DESCRIPTION
This PR is to create a variable to control sealing. It's set to 'true' always currently. This must be set to 'false' when using Windows images.