### PR TITLE
Allow to specify timeout for QCOW2 image download

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 image_path: /tmp
 image_cache_download: true
+image_download_timeout: 180
 template_cluster: Default
 template_name: mytemplate
 template_memory: 2GiB

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -15,6 +15,7 @@
     dest: "{{ image_path_st.stat.isdir | ternary(image_path~'/'~qcow_url.rpartition('/')[-1], image_path) | regex_replace('//', '/') }}"
     force: "{{ not image_cache_download }}"
     checksum: "{{ image_checksum | default(omit) }}"
+    timeout: "{{ image_download_timeout }}"
   register: downloaded_file
   tags:
     - ovirt-template-image


### PR DESCRIPTION
When we are getting QCOW2 image by the means of `get_url` module, we use the default timeout for that module which is 10 seconds. It seems quite restrictive given that we may be downloading files with size of several hundreds of megabytes. This way users may specify their own timeout for image download. I chose 180 as default value, but I can of course change it if you think that's too much.