### PR TITLE
ovirt-ansible-image-template: bump ansible to 2.9 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ So you can use any of these names. This documentation and examples in this repos
 Requirements
 ------------
 
- * Ansible version 2.7 or higher.
- * Python SDK version 4.2 or higher.
+ * Ansible version 2.9 or higher.
+ * Python SDK version 4.3 or higher.
  * oVirt has to be 4.1 or higher and [ovirt-imageio] must be installed and running.
  * CA certificate of oVirt engine. The path to CA certificate must be specified in the `ovirt_ca` variable.
 

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
-  - fc29
-  - fc28
+  - fc30
   - el7
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3", "ovirt-4.2" ]
+  master: [ "ovirt-master" ]

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-VERSION="1.1.13"
+VERSION="1.2.0"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
 
   platforms:
   - name: EL

--- a/ovirt-ansible-image-template.spec.in
+++ b/ovirt-ansible-image-template.spec.in
@@ -14,7 +14,7 @@ Group:          Virtualization/Management
 BuildArch:      noarch
 Url:            http://www.ovirt.org
 
-Requires: ansible >= 2.7.2
+Requires: ansible >= 2.9.0
 
 %description
 This Ansible role provide funtionality to create virtual machine template from disk

--- a/tasks/glance_image.yml
+++ b/tasks/glance_image.yml
@@ -19,14 +19,15 @@
         - always
 
     - name: Fetch storages
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
         auth: "{{ ovirt_auth }}"
+      register: sd_info
       tags:
         - ovirt-template-image
 
     - name: Find data domain
       set_fact:
-        disk_storage_domain: "{{ ovirt_storage_domains|json_query(the_query)|list|first}}"
+        disk_storage_domain: "{{ sd_info.ovirt_storage_domains|json_query(the_query)|list|first }}"
       vars:
         the_query: "[?type=='data']"
       tags:

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -102,7 +102,8 @@
       ovirt_disk_info:
         auth: "{{ ovirt_auth }}"
         pattern: "id={{ ovirt_disk.id }}"
-      until: (ovirt_disks is defined) and (ovirt_disks[0].status != "locked")
+      register: disk_info
+      until: ((ovirt_disk is defined) and (ovirt_disk.disk.status != "locked")) or ((disk_info is defined) and (disk_info.ovirt_disks[0].status != "locked"))
       retries: 20
       delay: 3
       when: template_info.ovirt_templates | length == 0
@@ -131,7 +132,7 @@
           type: "{{ template_type | default(omit) }}"
           cloud_init: "{{ {'user_name': 'root', 'authorized_ssh_keys': lookup('file', tmp_private_key_file~'.pub')} if template_prerequisites_tasks is defined else omit }}"
           disks:
-            - id: "{{ ovirt_disk.id }}"
+            - id: "{{ disk_info.ovirt_disks[0].id }}"
               bootable: true
               interface: "{{ template_disk_interface }}"
           nics: "{{ template_nics }}"
@@ -182,17 +183,17 @@
     - block:
         - name: Resize disk if smaller than template_disk_size
           ovirt_disk:
-            id: "{{ ovirt_disk.id }}"
+            id: "{{ disk_info.ovirt_disks[0].id }}"
             vm_name: "{{ vm_name }}"
             auth: "{{ ovirt_auth }}"
             size: "{{ template_disk_size }}"
 
         - name: Wait for resize
           ovirt_disk:
-            id: "{{ ovirt_disk.id }}"
+            id: "{{ disk_info.ovirt_disks[0].id }}"
             auth: "{{ ovirt_auth }}"
           register: resized_disk
-          until: resized_disk.disk.provisioned_size != ovirt_disk.disk.provisioned_size
+          until: resized_disk.disk.provisioned_size != disk_info.ovirt_disks[0].provisioned_size
           retries: "{{ (disk_resize_timeout / 3) | int }}"
           delay: 3
       when:

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -53,21 +53,23 @@
         - always
 
     - name: Fetch the datacenter name
-      ovirt_datacenter_facts:
+      ovirt_datacenter_info:
         auth: "{{ ovirt_auth }}"
         pattern: "Clusters.name = {{ template_cluster }}"
+      register: dc_info
 
     - name: Fetch storages
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "datacenter={{ ovirt_datacenters[0].name }}"
+        pattern: "datacenter={{ dc_info.ovirt_datacenters[0].name }}"
+      register: sd_info
       when: template_disk_storage is undefined
       tags:
         - ovirt-template-image
 
     - name: Find data domain
       set_fact:
-        disk_storage_domain: "{{ ovirt_storage_domains|json_query(the_query)|list|first}}"
+        disk_storage_domain: "{{ sd_info.ovirt_storage_domains|json_query(the_query)|list|first }}"
       when: template_disk_storage is undefined
       vars:
         the_query: "[?type=='data']"
@@ -75,9 +77,10 @@
         - ovirt-template-image
 
     - name: Check if template already exists
-      ovirt_template_facts:
+      ovirt_template_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "name={{ template_name }} and datacenter={{ ovirt_datacenters[0].name }}"
+        pattern: "name={{ template_name }} and datacenter={{ dc_info.ovirt_datacenters[0].name }}"
+      register: template_info
       tags:
         - ovirt-template-image
 
@@ -89,20 +92,20 @@
         format: "{{ template_disk_format | default(omit) }}"
         image_path: "{{ downloaded_file.dest }}"
         storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
-        force: "{{ ovirt_templates | length == 0 }}"
+        force: "{{ template_info.ovirt_templates | length == 0 }}"
       register: ovirt_disk
-      when: ovirt_templates | length == 0
+      when: template_info.ovirt_templates | length == 0
       tags:
         - ovirt-template-image
 
     - name: Wait until the qcow image is unlocked by the oVirt engine
-      ovirt_disk_facts:
+      ovirt_disk_info:
         auth: "{{ ovirt_auth }}"
         pattern: "id={{ ovirt_disk.id }}"
       until: (ovirt_disks is defined) and (ovirt_disks[0].status != "locked")
-      retries: 10
+      retries: 20
       delay: 3
-      when: ovirt_templates | length == 0
+      when: template_info.ovirt_templates | length == 0
       tags:
         - ovirt-template-image
 
@@ -135,18 +138,19 @@
 
       - block:
         - name: Wait for VMs IPv4
-          ovirt_vm_facts:
+          ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "name={{ vm_name }}"
             fetch_nested: true
             nested_attributes: ips
-          until: "ovirt_vms | ovirtvmipv4 | length > 0"
+          register: vm_info
+          until: "vm_info.ovirt_vms | ovirtvmipv4 | length > 0"
           retries: 10
           delay: 5
 
         - name: Set Ip of the VM
           set_fact:
-            vm_ip: "{{ ovirt_vms | ovirtvmipv4 }}"
+            vm_ip: "{{ vm_info.ovirt_vms | ovirtvmipv4 }}"
 
         - name: Include prerequisites tasks for VM
           import_tasks: "{{ template_prerequisites_tasks if template_prerequisites_tasks is defined else 'empty.yml' }}"
@@ -173,7 +177,7 @@
 
         when: template_prerequisites_tasks is defined
 
-      when: ovirt_templates | length == 0
+      when: template_info.ovirt_templates | length == 0
 
     - block:
         - name: Resize disk if smaller than template_disk_size
@@ -193,7 +197,7 @@
           delay: 3
       when:
         - (template_disk_size | regex_replace('GiB') | int) > (qcow2_size | regex_replace('GiB') | int)
-        - ovirt_templates | length == 0
+        - template_info.ovirt_templates | length == 0
 
     - name: Create template
       ovirt_template:
@@ -203,7 +207,7 @@
         cluster: "{{ template_cluster }}"
         timeout: "{{ template_timeout }}"
         seal: "{{ template_seal }}"
-      when: ovirt_templates | length == 0
+      when: template_info.ovirt_templates | length == 0
       tags:
         - ovirt-template-image
 
@@ -219,7 +223,7 @@
         auth: "{{ ovirt_auth }}"
         state: absent
         name: "{{ vm_name }}"
-      when: ovirt_templates | length == 0
+      when: template_info.ovirt_templates | length == 0
       tags:
         - ovirt-template-image
 


### PR DESCRIPTION
Bump ansible to 2.9

- keep only "ovirt-master" in automation.yaml    
- bump project version to 1.2.0 in build.sh 
- change in all tasks *_facts to *_info modules because of depreciation in ansible 2.13
   - it cannot be simply renamed to _info module because it does not return ansible_facts so all variables need to be registered and then used (https://docs.ansible.com/ansible/latest/modules/ovirt_api_info_module.html#notes)
- remove all unnecessary libraries and update tasks to match from ansible 2.9 and not lib 
- use ansible>=2.9.0 in 
  - ovirt-ansible-image-template.spec.in for build  
  - requirements.txt for manual install of ansible from pip
  - meta/main.yml for info in ansible galaxy
  - change ansible and sdk version in  README.md

https://bugzilla.redhat.com/show_bug.cgi?id=1762259
@machacekondra @mwperina 