### PR TITLE
Add qcow_after_download_tasks mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Role Variables
 | template_operating_system | UNDEF | Operating system of the template like: other, rhel_7x64, debian_7, see others in ovirt_template module. |
 | glance_image_provider        | UNDEF (mandatory if qcow_url is not used)            | Name of the glance image provider.                    |
 | glance_image            | UNDEF (mandatory if qcow_url is not used)               | This parameter specifies the name of disk in glance provider to be imported as template. |
+| qcow_after_download_tasks | UNDEF          | Works only with qcow image. Specify a path to Ansible tasks file, which should be executed right after the qcow image has been downloaded. This can be used for example for extracting the image. See example below. |
 | template_prerequisites_tasks | UNDEF | Works only with qcow image. Specify a path to Ansible tasks file, which should be executed on virtual machine before creating a template from it. Note that qcow image must contain guest agent which reports IP address. |
 
 The `template_disks` List of dictionaries can contain following attributes:
@@ -135,6 +136,18 @@ Example Playbook
 
   roles:
     - ovirt-image-template
+```
+
+Example of `qcow_after_download_tasks` task file
+------------------------------------------------
+```yaml
+---
+- name: Extract downloaded QCOW image
+  command: "/usr/bin/unxz --force --keep {{ qcow_image }}"
+
+- name: Set qcow_image to new value
+  set_fact:
+    qcow_image: "{{ (qcow_image | splitext)[0] }}"
 ```
 
 [![asciicast](https://asciinema.org/a/111478.png)](https://asciinema.org/a/111478)

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -22,8 +22,16 @@
   tags:
     - ovirt-template-image
 
+- name: Register path to downloaded image
+  set_fact:
+    qcow_image: "{{ downloaded_file.dest }}"
+
+- name: Perform tasks after qcow image download
+  include_tasks: "{{ qcow_after_download_tasks }}"
+  when: qcow_after_download_tasks is defined
+
 - name: Check file type
-  command: "/usr/bin/file {{ downloaded_file.dest | quote }}"
+  command: "/usr/bin/file {{ qcow_image | quote }}"
   changed_when: false
   register: filetype
   tags:
@@ -92,7 +100,7 @@
         name: "{{ template_disk_name | default(template_name) }}"
         size: "{{ qcow2_size }}"
         format: "{{ template_disk_format | default(omit) }}"
-        image_path: "{{ downloaded_file.dest }}"
+        image_path: "{{ qcow_image }}"
         storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
         force: "{{ template_info.ovirt_templates | length == 0 }}"
       register: ovirt_disk
@@ -230,7 +238,7 @@
   always:
     - name: Remove downloaded image
       file:
-        path: "{{ downloaded_file.dest }}"
+        path: "{{ qcow_image }}"
         state: absent
       when: not image_cache_download
 


### PR DESCRIPTION
Providing path to a task file to `qcow_after_download_tasks` lets you perform additional actions on downloaded QCOW image before it is uploaded to oVirt. The most obvious use case here is extracting the image in case it is archived.