### PR TITLE
Fix: allow to read ssh key on remote host

### DIFF
--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -119,7 +119,7 @@
           creates: "{{ tmp_private_key_file }}"
         when: template_prerequisites_tasks is defined
 
-      - name: Get SHH key
+      - name: Get SSH key
         command: "cat {{ tmp_private_key_file~'.pub' }}"
         register: key_resp
         when: template_prerequisites_tasks is defined

--- a/tasks/qcow2_image.yml
+++ b/tasks/qcow2_image.yml
@@ -119,6 +119,11 @@
           creates: "{{ tmp_private_key_file }}"
         when: template_prerequisites_tasks is defined
 
+      - name: Get SHH key
+        command: "cat {{ tmp_private_key_file~'.pub' }}"
+        register: key_resp
+        when: template_prerequisites_tasks is defined
+
       - name: Create vm
         ovirt_vm:
           auth: "{{ ovirt_auth }}"
@@ -132,7 +137,7 @@
           cpu_cores: "{{ template_cpu }}"
           operating_system: "{{ template_operating_system }}"
           type: "{{ template_type | default(omit) }}"
-          cloud_init: "{{ {'user_name': 'root', 'authorized_ssh_keys': lookup('file', tmp_private_key_file~'.pub')} if template_prerequisites_tasks is defined else omit }}"
+          cloud_init: "{{ {'user_name': 'root', 'authorized_ssh_keys': key_resp.stdout } if template_prerequisites_tasks is defined else omit }}"
           disks:
             - id: "{{ disk_info.ovirt_disks[0].id }}"
               bootable: true


### PR DESCRIPTION
Issue: `lookup('file', name)` reads files on the host where the playbook is being executed.
Fixes #71
